### PR TITLE
pyproject.toml and uvloop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,15 @@
 # PyCharm
 .idea/
 
+# VSCode
+.vscode/
+
 # Python virtualenv environment folders
 env/
 env3/
 .env/
 venv/
+.venv/
 
 # Bot local files
 *.db
@@ -30,3 +34,4 @@ plugins/*/*.json
 
 # other stuff
 plugins/sabnzbdapi/sabnzbdapi.py
+poetry.lock

--- a/core/chat_functions.py
+++ b/core/chat_functions.py
@@ -61,9 +61,11 @@ async def room_send(
         if send_response.status_code == "M_LIMIT_EXCEEDED":
             # we're being rate-limited, try again after the given time
             send_retries += 1
-            logger.warning(f"Ratelimit hit with {message_type} to {room_id}! Server is asking us to wait {send_response.retry_after_ms}ms. "
-                           f"Sending again in {math.ceil(send_response.retry_after_ms/1000)}s (Retry: {send_retries}/{max_retries}).")
-            await sleep(math.ceil(send_response.retry_after_ms/1000))
+            logger.warning(
+                f"Ratelimit hit with {message_type} to {room_id}! Server is asking us to wait {send_response.retry_after_ms}ms. "
+                f"Sending again in {math.ceil(send_response.retry_after_ms/1000)}s (Retry: {send_retries}/{max_retries})."
+            )
+            await sleep(math.ceil(send_response.retry_after_ms / 1000))
             send_response: RoomSendResponse or RoomSendError = await client.room_send(room_id, message_type, content, tx_id, ignore_unverified_devices)
 
         else:

--- a/main.py
+++ b/main.py
@@ -2,6 +2,14 @@
 
 import logging
 import asyncio
+
+try:
+    import uvloop
+
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+except ModuleNotFoundError:
+    logging.info("not using uvloop, falling back to asyncio event loop")
+
 import os
 import sys
 import traceback

--- a/main.py
+++ b/main.py
@@ -160,4 +160,4 @@ async def main():
             await client.close()
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.new_event_loop().run_until_complete(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[tool.black]
+line-length = 160
+
+[tool.poetry]
+name = "nio-smith"
+version = "0.0.0"
+description = "A plugin-based bot for @matrix-org"
+authors = ["alturiak"]
+license = "Apache-2.0"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+matrix-nio = {version = ">=0.19.0", extras = ["e2e"]}
+fuzzywuzzy = ">=0.18.0"
+Markdown = ">=3.3.6"
+PyYAML = ">=6.0"
+jsonpickle = ">=2.1.0"
+Pillow = ">=9.0.1"
+blurhash-python = ">=1.1.3"
+requests = ">=2.27.1"
+xkcd = "^2.4.2"
+commonmark = "^0.9.1"
+recommonmark = "^0.7.1"
+dateparser = "^1.1.1"
+humanize = "^4.0.0"
+pytz = "^2022.1"
+freetranslate = "^0.2.2"
+wikipedia = "^1.4.0"
+python-Levenshtein = "^0.12.2"
+
+[tool.poetry.dev-dependencies]
+black = {version = "^22.3.0", allow-prereleases = true}
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ humanize = "^4.0.0"
 pytz = "^2022.1"
 freetranslate = "^0.2.2"
 wikipedia = "^1.4.0"
+uvloop = {version = "^0.16.0", markers = 'platform_system != "Windows"'}
 python-Levenshtein = "^0.12.2"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ jsonpickle>=2.1.0
 Pillow>=9.0.1
 blurhash-python>=1.1.3
 requests>=2.27.1
+uvloop==0.16.0; platform_system != "Windows"


### PR DESCRIPTION
asyncio.get_event_loop() without existing loop raises a deprecation info. we should use asyncio.new_event_loop()
[uvloop](https://uvloop.readthedocs.io/) is a fast drop-in replacement for the asyncio event loop, available on unix systems. my changes should not break existing setups or hinder people from setting up a new bot on a windows system.
the pyproject.toml file contains dependencies for the use with [poetry](https://python-poetry.org/) and your preferred black line-length configurations.    