### PR TITLE
argument parsing for mutli word arguments

### DIFF
--- a/core/bot_commands.py
+++ b/core/bot_commands.py
@@ -1,4 +1,18 @@
 from nio import RoomMessageText, AsyncClient, MatrixRoom
+import re
+
+
+def _parse_args(input: str) -> "list[str]":
+    """splits arguments at spaces but keeps the argument as one if its encapsulated by quotes"""
+    pattern1 = re.compile(r"([\"\'].+?[\"\'])")
+    pattern2 = re.compile(r"[\"\']")
+    args_list = []
+    for args in re.split(pattern1, input):
+        if re.match(pattern2, args):
+            args_list.append(args.strip("\"'"))
+        else:
+            args_list.extend(args.split())
+    return args_list[1:]
 
 
 class Command(object):
@@ -24,5 +38,5 @@ class Command(object):
         self.command = command
         self.room: MatrixRoom = room
         self.event: RoomMessageText = event
-        self.args = self.command.split()[1:]
+        self.args = _parse_args(self.command)
         self.plugin_loader = plugin_loader

--- a/core/bot_commands.py
+++ b/core/bot_commands.py
@@ -7,7 +7,7 @@ def _parse_args(input: str) -> "list[str]":
     pattern1 = re.compile(r"([\"\'].+?[\"\'])")
     pattern2 = re.compile(r"[\"\']")
     args_list = []
-    for args in re.split(pattern1, input):
+    for args in re.split(pattern1, " ".join(input.split()[1:])):
         if re.match(pattern2, args):
             args_list.append(args.strip("\"'"))
         else:

--- a/plugins/sample/sample.py
+++ b/plugins/sample/sample.py
@@ -104,6 +104,8 @@ def setup():
     """Get the bot's client instance from plugin.get_client instead of the command"""
     plugin.add_command("sample_get_client", sample_get_client, "Post a message using the client instance of `plugin.get_client()`")
 
+    plugin.add_command("sample_echo_arguments", sample_echo_arguments, "echos the python list of arguments the bot received.")
+
     """The following part demonstrates registering timers by fixed interval and timedelta"""
     if timers_enabled:
         plugin.add_timer(timer_daily, frequency="daily")
@@ -522,6 +524,16 @@ async def sample_get_client(command: Command):
     """
 
     await plugin.send_notice(await plugin.get_client(), command.room.room_id, "This message uses plugin.get_client()")
+
+
+async def sample_echo_arguments(command: Command):
+    """
+    Sends a message with all arguments the bot received formatted as a python list
+    :param command:
+    :return:
+    """
+
+    await plugin.respond_message(command, f"`{command.args}`")
 
 
 setup()


### PR DESCRIPTION
splitting the arguments array with respect to quotation allows taking multi-word arguments for commands. 
![image](https://user-images.githubusercontent.com/63156923/174499181-2232ddb9-be82-46a5-aa5b-faf9348f4c47.png)

```py
# if you prefer a oneliner and hate maintainable code :-)
import itertools
# ...
class Command(object):
  # ...
  self.args = list(itertools.chain.from_iterable([[args.strip("\"'")] if re.match(r'[\"\']', args) else args.split() for args in re.split(r'([\"\'].+?[\"\'])', ' '.join(self.command.split()[1:]))]))[1:]
```