### PR TITLE
Feature cashup comment

### DIFF
--- a/plugins/cashup/cashup.py
+++ b/plugins/cashup/cashup.py
@@ -278,12 +278,6 @@ async def register(command):
         for arg in command.args:
             # remove all ; from arg element;
             arg = arg.replace(";", "")
-            # (just in case) remove all , from arg element;
-            arg = arg.replace(",", "")
-            # skip empty fields
-            # ("Name 0.1 ," -> "["Name", "0.1", ","] -> arg[2] "," -> replace "")
-            if len(arg) == 0:
-                continue
             # find any numbers in string (eg: 12; 12,1; 12.1)
             match_arg_nr = re.search("\d*[.,]?\d+", arg)
             # returns a match object
@@ -298,6 +292,13 @@ async def register(command):
                     await plugin.respond_notice(command, response_input_error)
                     return
             else:
+                # (just in case) remove all "," from arg name element
+                # dont do this for number elements as it harms percentage value
+                arg = arg.replace(",", "")
+                # skip empty fields
+                # ("Name 0.1 ," -> "["Name", "0.1", ","] -> arg[2] "," -> replace "")
+                if len(arg) == 0:
+                    continue
                 new_names.append(arg)
         if len(new_names) > 1 and len(new_names) == len(new_percentages):
             # every name got a percentage value


### PR DESCRIPTION
Sometimes its nice to add a comment what the expense was used for.

Examples:
```
!n cashup-ae SomeonesName 12€ cake
!n cashup-ae 4,50€ 2 cones of ice cream 
```

Also includes changes to make the `cashup-registration` method user input more fool prove.